### PR TITLE
Example that fail unicode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
         if [ "$PYTHON_VERSION" == "2.7" ]; then
           conda install --yes --quiet mayavi;
           conda upgrade --yes --all;
-          conda upgrade --yes pyface;
+          pip install --upgrade pyface;
         fi;
       fi;
     - pip install -r requirements.txt

--- a/examples/plot_quantum.py
+++ b/examples/plot_quantum.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+r"""
+======================
+Some Quantum Mechanics
+======================
+
+We start with a two spin system :math:`\uparrow` and :math:`\downarrow`
+
+"""
+# Author: Óscar Nájera
+
+from __future__ import division, absolute_import, print_function
+
+
+def hamiltonian(M, mu):
+    r"""Generate a single orbital isolated atom Hamiltonian in particle-hole
+    symmetry. Include chemical potential for grand Canonical calculations
+
+    .. math::
+        \mathcal{H} - \mu N = M(n_\uparrow - n_\downarrow)
+        - \mu(n_\uparrow + n_\downarrow)
+    """
+    pass
+
+###############################################################################
+# Double occupation
+# -----------------
+#
+# To find out the double occupation one uses the relation
+# (Works in Sphinx-Gallery)
+
+import matplotlib.pylab as plt
+import numpy as np
+x = np.linspace(0, 1, 20)
+plt.plot(x, (1 - x**2) / 4)
+plt.ylabel('$\\langle n_\\uparrow n_\\downarrow \\rangle$')
+plt.show()
+
+###############################################################################
+#
+# .. math:: \langle n_\uparrow n_\downarrow \rangle = \frac{2\langle V \rangle}{U}+\frac{1}{4}
+
+print('pass')
+
+###############################################################################
+# (Does not work in Sphinx-Gallery)
+# ---------------------------------
+
+plt.plot(x, (1 - x) / 4)
+plt.ylabel(r'$\langle n_\uparrow n_\downarrow \rangle$')
+plt.xlabel('U')
+plt.show()


### PR DESCRIPTION
@Eric89GXL This is my very particular use case that still fails after your great work on unicode(https://github.com/sphinx-gallery/sphinx-gallery/pull/106) if you want to give it a try, my other cases seem to work now on py2, thanks. The example runs without problems in python 2 and 3, is thus valid code. And builds in Sphinx-Gallery python 3 master and this branch but fails on python 2 in both cases. Travis is green because the gallery continues to build despite errors, it will stop to be so once https://github.com/sphinx-gallery/sphinx-gallery/pull/97 is merged.

The issue in this example is very particular to my use case, I have latex in the python code. very particular an \uparrow and for lazyness I use raw strings not to need to escape the backslash. But \u means to python that an unicode character is to be interpreted, that's where the problem comes.

Second I have put a patch to make travis pass the test on the mayavi build, the one that has the issue with pygments. It is a problem of the conda virtual environment and the version of pyface(4.4.0) and some of its dependencies. Previously I forced the update of pyface(4.5.0) within conda, but nowt the versions are checked more strickly within conda and pyface does not update, so the update is forced in pip to pyface(5.0.0) It works well enough for our examples.
